### PR TITLE
fix: error with disposing notification

### DIFF
--- a/lib/elegant_notification.dart
+++ b/lib/elegant_notification.dart
@@ -291,8 +291,9 @@ class _ElegantNotificationState extends State<ElegantNotification>
 
   @override
   void dispose() {
-    super.dispose();
+    slideController.dispose();
     closeTimer.cancel();
+    super.dispose();
   }
 
   @override


### PR DESCRIPTION
Fixes exceptions caused by faulty disposal method
```
════════ Exception caught by widgets library ═══════════════════════════════════
_ElegantNotificationState#512a0(ticker active) was disposed with an active Ticker.
════════════════════════════════════════════════════════════════════════════════

════════ Exception caught by animation library ═════════════════════════════════
Looking up a deactivated widget's ancestor is unsafe.
════════════════════════════════════════════════════════════════════════════════
```